### PR TITLE
🔧 update: improve PR title generation prompt clarity

### DIFF
--- a/src/utils/copilot.ts
+++ b/src/utils/copilot.ts
@@ -48,7 +48,8 @@ Prefixes: feature, fix, docs, chore, test, refactor
 Rules: lowercase kebab-case, 2-5 words max. Return ONLY the branch name.
 Examples: fix/login-timeout | feature/user-profile-page | docs/update-readme`;
 
-const PR_DESCRIPTION_SYSTEM_PROMPT_BASE = `GitHub PR description generator. Return JSON: {"title":"<72 chars>","body":"## Summary\\n...\\n\\n## Changes\\n- ...\\n\\n## Test Plan\\n..."}`;
+const PR_DESCRIPTION_SYSTEM_PROMPT_BASE = `GitHub PR description generator. Return JSON: {"title":"<72 chars>","body":"## Summary\\n...\\n\\n## Changes\\n- ...\\n\\n## Test Plan\\n..."}
+IMPORTANT: The title must capture the overall theme or goal of the PR — NOT enumerate individual changes. Think: what problem does this PR solve or what capability does it add? Keep it focused and specific but high-level.`;
 
 function getPRDescriptionSystemPrompt(convention: CommitConvention): string {
   if (convention === 'clean-commit') {
@@ -56,17 +57,17 @@ function getPRDescriptionSystemPrompt(convention: CommitConvention): string {
 CRITICAL: The PR title MUST follow the Clean Commit format exactly: <emoji> <type>: <description>
 Emoji/type table: 📦 new, 🔧 update, 🗑️ remove, 🔒 security, ⚙️ setup, ☕ chore, 🧪 test, 📖 docs, 🚀 release
 Title examples: 📦 new: add user authentication | 🔧 update: improve error handling | 🗑️ remove: drop legacy API
-Rules: title follows convention, present tense, max 72 chars; body has Summary, Changes (bullets), Test Plan sections. Return ONLY the JSON object, no fences.`;
+Rules: title follows convention, present tense, max 72 chars, describes the PR theme not individual commits; body has Summary, Changes (bullets), Test Plan sections. Return ONLY the JSON object, no fences.`;
   }
   if (convention === 'conventional') {
     return `${PR_DESCRIPTION_SYSTEM_PROMPT_BASE}
 CRITICAL: The PR title MUST follow Conventional Commits format: <type>[(<scope>)]: <description>
 Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
 Title examples: feat: add user authentication | fix(auth): resolve token expiry | docs: update contributing guide
-Rules: title follows convention, present tense, max 72 chars; body has Summary, Changes (bullets), Test Plan sections. Return ONLY the JSON object, no fences.`;
+Rules: title follows convention, present tense, max 72 chars, describes the PR theme not individual commits; body has Summary, Changes (bullets), Test Plan sections. Return ONLY the JSON object, no fences.`;
   }
   return `${PR_DESCRIPTION_SYSTEM_PROMPT_BASE}
-Rules: title concise present tense; body has Summary, Changes (bullets), Test Plan sections. Return ONLY the JSON object, no fences.`;
+Rules: title concise present tense, describes the PR theme not individual commits; body has Summary, Changes (bullets), Test Plan sections. Return ONLY the JSON object, no fences.`;
 }
 
 const CONFLICT_RESOLUTION_SYSTEM_PROMPT = `Git merge conflict advisor. Explain each side, suggest resolution strategy. Never auto-resolve — guidance only. Be concise and actionable.`;


### PR DESCRIPTION
## Summary
Improves the AI prompt instructions for PR title generation to better guide the model toward producing high-level, theme-focused titles rather than enumerating individual changes.

## Changes
- Added an `IMPORTANT` directive to the base PR description prompt clarifying that titles should capture the overall PR theme or goal, not list individual changes
- Updated the `Rules` clause across all three commit convention branches (`clean-commit`, `conventional`, and default) to explicitly state that the title describes the PR theme, not individual commits

## Test Plan
- Generate PR descriptions using each commit convention (Clean Commit, Conventional Commits, and default) and verify that the resulting titles reflect the overall PR goal rather than enumerating specific commits or file changes
- Confirm no regressions in JSON output structure or format compliance