### PR TITLE
🔧 update: improve CI workflow for GitHub token handling and npm publish

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,5 +50,5 @@ jobs:
           package-scope: '@warengonzaga'
           access: 'public'
           npm-token: "${{ secrets.NPM_TOKEN }}"
-          github-token: "${{ github.token }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           dry-run: "${{ github.event.inputs.dry-run || 'false' }}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           package-manager: 'bun'
           registry: 'both'
+          package-scope: '@warengonzaga'
           access: 'public'
           npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT || github.token }}
           dry-run: ${{ github.event.inputs.dry-run || 'false' }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,6 +49,6 @@ jobs:
           registry: 'both'
           package-scope: '@warengonzaga'
           access: 'public'
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GH_PAT || github.token }}
-          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+          npm-token: "${{ secrets.NPM_TOKEN }}"
+          github-token: "${{ github.token }}"
+          dry-run: "${{ github.event.inputs.dry-run || 'false' }}"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,4 +102,19 @@ const main = defineCommand({
   },
 });
 
-runMain(main);
+// Force a clean exit once the command finishes.
+//
+// Several dependencies keep Node's event loop alive after a command completes:
+//   - `@clack/prompts` leaves stdin in raw mode with listeners attached after prompts resolve
+//   - `@github/copilot-sdk` retains keep-alive HTTP sockets (and likely internal timers)
+//
+// Without an explicit exit, successful commands (`commit`, `switch`, `submit`, etc.) leave the
+// terminal hanging until the user hits Ctrl+C. Exiting here — after `runMain` has flushed
+// citty's own output — keeps the fix in one place instead of sprinkling `process.exit(0)`
+// across every command's success path.
+runMain(main)
+  .then(() => process.exit(process.exitCode ?? 0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -289,7 +289,6 @@ export default defineCommand({
     }
 
     success(`Committed: ${pc.bold(finalMessage)}`);
-    process.exit(0);
   },
 });
 

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -289,6 +289,7 @@ export default defineCommand({
     }
 
     success(`Committed: ${pc.bold(finalMessage)}`);
+    process.exit(0);
   },
 });
 


### PR DESCRIPTION
This pull request introduces a few minor updates to the workflow configuration and command execution behavior. The most notable changes involve improvements to the package publishing workflow and explicit process termination in the commit command.

Workflow configuration improvements:
* [`.github/workflows/package.yml`](diffhunk://#diff-170ebc8e4dc40acf23cbe0ecce5f3e2aef1652511f59860db704106b197e1d52R50-R54): Added a `package-scope` option to specify the package namespace and updated the formatting of environment variable references for `npm-token`, `github-token`, and `dry-run` to use string interpolation for consistency.

Command execution behavior:
* [`src/commands/commit.ts`](diffhunk://#diff-ae7d70033d3bac66c3fb6f289e5de37ff2336967e2a9831ad9654214c12122b6R292): Added an explicit call to `process.exit(0)` after a successful commit to ensure the process terminates cleanly.