### PR TITLE
🔧 update: CI workflow for GitHub token handling and CLI improvements

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -50,5 +50,5 @@ jobs:
           package-scope: '@warengonzaga'
           access: 'public'
           npm-token: "${{ secrets.NPM_TOKEN }}"
-          github-token: "${{ github.token }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           dry-run: "${{ github.event.inputs.dry-run || 'false' }}"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -47,7 +47,8 @@ jobs:
         with:
           package-manager: 'bun'
           registry: 'both'
+          package-scope: '@warengonzaga'
           access: 'public'
           npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.GH_PAT || github.token }}
           dry-run: ${{ github.event.inputs.dry-run || 'false' }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -49,6 +49,6 @@ jobs:
           registry: 'both'
           package-scope: '@warengonzaga'
           access: 'public'
-          npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GH_PAT || github.token }}
-          dry-run: ${{ github.event.inputs.dry-run || 'false' }}
+          npm-token: "${{ secrets.NPM_TOKEN }}"
+          github-token: "${{ github.token }}"
+          dry-run: "${{ github.event.inputs.dry-run || 'false' }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,14 +41,14 @@ Reference: https://github.com/wgtechlabs/clean-commit
 
 Use a scope to clarify which part of the CLI is affected:
 
-- `(setup)` — contrib setup command
-- `(sync)` — contrib sync command
-- `(start)` — contrib start command
-- `(commit)` — contrib commit command
-- `(update)` — contrib update command
-- `(submit)` — contrib submit command
-- `(clean)` — contrib clean command
-- `(status)` — contrib status command
+- `(setup)` — cn setup command
+- `(sync)` — cn sync command
+- `(start)` — cn start command
+- `(commit)` — cn commit command
+- `(update)` — cn update command
+- `(submit)` — cn submit command
+- `(clean)` — cn clean command
+- `(status)` — cn status command
 - `(git)` — git utility
 - `(gh)` — GitHub CLI utility
 - `(copilot)` — Copilot SDK integration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ bun run lint:fix
 1. **Sync your fork** — keep your fork current:
 
    ```bash
-   contrib sync   # if you have contribute-now installed
+   cn sync   # if you have contribute-now installed
    # or manually:
    git fetch upstream && git reset --hard upstream/dev
    ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It natively supports multiple workflow models and commit conventions, with AI-po
 
 ## Workflow Modes
 
-Pick the model that matches your project during `contrib setup`. contribute-now adapts its commands to your chosen workflow automatically — no manual branch names to remember.
+Pick the model that matches your project during `cn setup`. contribute-now adapts its commands to your chosen workflow automatically — no manual branch names to remember.
 
 | Mode | Branches | Strategy | Default |
 |------|----------|----------|:-------:|
@@ -44,12 +44,14 @@ Or install globally:
 
 ```bash
 bun install -g contribute-now
-contrib setup
+contribute setup
 ```
 
 `contribute-now` now runs on Bun at runtime. Use `bunx` for one-off execution and `bun install -g` for a global install.
 
-> `contrib`, `contribute`, and `cn` all invoke the same binary — use whichever you prefer.
+> `contribute` is the primary command; `cn` is the short alias for the same binary — use whichever you prefer.
+>
+> The older `contrib` alias is being phased out. Please switch to `contribute` or `cn`.
 >
 > **Fun fact:** `cn` is shorter than `git`. Yes, your workflow command is now faster to type than git itself. 🚀
 
@@ -72,13 +74,14 @@ npm install -g bun
 npm install -g contribute-now
 ```
 
-Once installed, you can use any of the three aliases:
+Once installed, you can use either alias:
 
 ```bash
-contrib setup     # classic
-contribute setup  # spelled out
-cn setup          # shortest — even shorter than git!
+contribute setup  # primary command — spelled out
+cn setup          # short alias — even shorter than git!
 ```
+
+> The legacy `contrib` alias still works but is being phased out. Prefer `contribute` or `cn`.
 
 ## Prerequisites
 
@@ -90,12 +93,12 @@ cn setup          # shortest — even shorter than git!
 
 ## Commands
 
-### `contrib setup`
+### `cn setup`
 
 Interactive setup wizard. Configures your repo's workflow mode, commit convention, your role, branch/remote names, and AI provider settings. Writes local config to `.git/contribute-now/config.json` by default.
 
 ```bash
-contrib setup
+cn setup
 ```
 
 Steps:
@@ -107,33 +110,33 @@ Steps:
 6. Confirm branch and remote names
 7. Write `.git/contribute-now/config.json` (or update `.contributerc.json` if that legacy file is still the active source)
 
-If you want to disable AI completely for a repo, run `contrib setup` and turn AI off, or set `"aiEnabled": false` in the active config file. Per-command `--no-ai` flags still work as one-off overrides when AI is enabled globally.
+If you want to disable AI completely for a repo, run `cn setup` and turn AI off, or set `"aiEnabled": false` in the active config file. Per-command `--no-ai` flags still work as one-off overrides when AI is enabled globally.
 
 If you want a cleaner output once you're familiar with the CLI, set `"showTips": false` in the active config file to hide the beginner quick guides and loading tips.
 
 ---
 
-### `contrib config`
+### `cn config`
 
 Inspect the active repo config or edit it without rerunning the full setup flow.
 
 ```bash
-contrib config
-contrib config --json
-contrib config --edit
+cn config
+cn config --json
+cn config --edit
 ```
 
 Use `--edit` to update workflow settings, branch names, commit convention, AI provider details, the stored Ollama Cloud API key, and to choose from the currently available Ollama Cloud models. Ollama Cloud uses the built-in default host and does not ask for a custom host URL.
 
 ---
 
-### `contrib sync`
+### `cn sync`
 
 Pull the latest changes from the correct remote branch based on your workflow and role.
 
 ```bash
-contrib sync         # with confirmation
-contrib sync --yes   # skip confirmation
+cn sync         # with confirmation
+cn sync --yes   # skip confirmation
 ```
 
 | Role | Clean Flow / Git Flow | GitHub Flow |
@@ -143,94 +146,94 @@ contrib sync --yes   # skip confirmation
 
 ---
 
-### `contrib start`
+### `cn start`
 
 Create a new feature branch from the correct base branch, with optional AI-powered branch naming.
 
 ```bash
 # Direct branch name
-contrib start feature/user-auth
+cn start feature/user-auth
 
 # Natural language — AI suggests the branch name
-contrib start "add user authentication"
+cn start "add user authentication"
 
 # Skip AI
-contrib start "add user authentication" --no-ai
+cn start "add user authentication" --no-ai
 ```
 
 ---
 
-### `contrib commit`
+### `cn commit`
 
 Stage your changes and create a validated, AI-generated commit message matching your configured convention.
 
 ```bash
-contrib commit                     # AI-generated message
-contrib commit --no-ai             # manual entry, still validated
-contrib commit --model gpt-4.1    # specific AI model
-contrib commit --group             # AI groups changes into atomic commits
+cn commit                     # AI-generated message
+cn commit --no-ai             # manual entry, still validated
+cn commit --model gpt-4.1    # specific AI model
+cn commit --group             # AI groups changes into atomic commits
 ```
 
 After the AI generates a message, you can **accept**, **edit**, **regenerate**, or **write manually**. Messages are always validated against your convention — with a soft warning if they don't match (you can still commit).
 
 **Group commit mode** (`--group`): AI analyzes all staged and unstaged changes, groups related files into logical atomic commits, and generates a commit message for each group. Great for splitting a large set of changes into clean, reviewable commits.
 
-If `aiEnabled` is set to `false` in `.contributerc.json`, `contrib commit` stays manual and `--group` is unavailable.
+If `aiEnabled` is set to `false` in `.contributerc.json`, `cn commit` stays manual and `--group` is unavailable.
 
 ---
 
-### `contrib update`
+### `cn update`
 
 Rebase your current branch onto the latest base branch, with AI guidance if conflicts occur.
 
 ```bash
-contrib update
-contrib update --no-ai   # skip AI conflict guidance
+cn update
+cn update --no-ai   # skip AI conflict guidance
 ```
 
 ---
 
-### `contrib submit`
+### `cn submit`
 
 Push your branch and open a pull request with an AI-generated title and description.
 
 ```bash
-contrib submit
-contrib submit --draft
-contrib submit --no-ai
-contrib submit --model gpt-4.1
+cn submit
+cn submit --draft
+cn submit --no-ai
+cn submit --model gpt-4.1
 ```
 
 ---
 
-### `contrib clean`
+### `cn clean`
 
 Delete merged branches and prune stale remote refs.
 
 ```bash
-contrib clean          # shows candidates, asks to confirm
-contrib clean --yes    # skip confirmation
+cn clean          # shows candidates, asks to confirm
+cn clean --yes    # skip confirmation
 ```
 
 ---
 
-### `contrib status`
+### `cn status`
 
 Show a sync status dashboard for your main, dev, and current branch.
 
 ```bash
-contrib status
+cn status
 ```
 
 ---
 
-### `contrib doctor`
+### `cn doctor`
 
 Diagnose the contribute-now CLI environment and configuration. Checks tools, dependencies, config, git state, fork setup, workflow, and environment.
 
 ```bash
-contrib doctor          # pretty-printed report
-contrib doctor --json   # machine-readable JSON output
+cn doctor          # pretty-printed report
+cn doctor --json   # machine-readable JSON output
 ```
 
 Checks include:
@@ -243,45 +246,45 @@ Checks include:
 
 ---
 
-### `contrib log`
+### `cn log`
 
 Show a colorized, workflow-aware commit log. By default it shows only **local unpushed commits** — the changes you've made since the last push (or since branching off the base branch). Use flags to switch between different views.
 
 ```bash
-contrib log                # local unpushed commits (default)
-contrib log --remote       # commits on remote not yet pulled
-contrib log --full         # full history for the current branch
-contrib log --all          # commits across all branches
-contrib log -n 50          # change the commit limit (default: 20)
-contrib log -b feature/x   # log for a specific branch
-contrib log --no-graph     # flat view without graph lines
+cn log                # local unpushed commits (default)
+cn log --remote       # commits on remote not yet pulled
+cn log --full         # full history for the current branch
+cn log --all          # commits across all branches
+cn log -n 50          # change the commit limit (default: 20)
+cn log -b feature/x   # log for a specific branch
+cn log --no-graph     # flat view without graph lines
 ```
 
 When no upstream tracking is set (branch hasn't been pushed yet), the command automatically compares against the base branch from your config (e.g., `origin/dev`). Protected branches are highlighted, and the current branch is color-coded for quick orientation.
 
 ---
 
-### `contrib branch`
+### `cn branch`
 
 List branches with workflow-aware labels and tracking status.
 
 ```bash
-contrib branch             # local branches
-contrib branch --all       # local + remote branches
-contrib branch --remote    # remote branches only
+cn branch             # local branches
+cn branch --all       # local + remote branches
+cn branch --remote    # remote branches only
 ```
 
 Branches are annotated with workflow labels (e.g., base, dev, feature) and tracking info (upstream, gone, no remote).
 
 ---
 
-### `contrib hook`
+### `cn hook`
 
 Install or uninstall a `commit-msg` git hook that validates every commit against your configured convention — no Husky or lint-staged needed.
 
 ```bash
-contrib hook install     # writes .git/hooks/commit-msg
-contrib hook uninstall   # removes it
+cn hook install     # writes .git/hooks/commit-msg
+cn hook uninstall   # removes it
 ```
 
 - Automatically skips merge commits, fixup, squash, and amend commits
@@ -289,13 +292,13 @@ contrib hook uninstall   # removes it
 
 ---
 
-### `contrib validate`
+### `cn validate`
 
 Validate a commit message against your configured convention. Exits `0` if valid, `1` if not — useful in CI pipelines or custom hooks.
 
 ```bash
-contrib validate "📦 new: user auth module"     # exit 0
-contrib validate "added stuff"                   # exit 1
+cn validate "📦 new: user auth module"     # exit 0
+cn validate "added stuff"                   # exit 1
 ```
 
 ---
@@ -364,7 +367,7 @@ feat!: redesign authentication API
 
 ## Config File
 
-`contrib setup` writes `.git/contribute-now/config.json` by default. If a legacy `.contributerc.json` already exists, it remains the active source until you migrate or remove it:
+`cn setup` writes `.git/contribute-now/config.json` by default. If a legacy `.contributerc.json` already exists, it remains the active source until you migrate or remove it:
 
 ```json
 {
@@ -379,7 +382,7 @@ feat!: redesign authentication API
 }
 ```
 
-Use `contrib config --edit` to change these values later without rerunning the full setup flow. If you are still on the legacy `.contributerc.json`, keep that file ignored until you migrate away from it.
+Use `cn config --edit` to change these values later without rerunning the full setup flow. If you are still on the legacy `.contributerc.json`, keep that file ignored until you migrate away from it.
 
 ---
 
@@ -429,7 +432,7 @@ This project is licensed under [GNU General Public License v3.0](https://opensou
 
 This project is created by **[Waren Gonzaga](https://github.com/warengonzaga)**, with the help of awesome [contributors](https://github.com/warengonzaga/contribute-now/graphs/contributors).
 
-[![contributors](https://contrib.rocks/image?repo=warengonzaga/contribute-now)](https://github.com/warengonzaga/contribute-now/graphs/contributors)
+[![contributors](https://cn.rocks/image?repo=warengonzaga/contribute-now)](https://github.com/warengonzaga/contribute-now/graphs/contributors)
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -9,13 +9,11 @@
         "@github/copilot-sdk": "^0.1.25",
         "@wgtechlabs/log-engine": "^2.3.1",
         "citty": "^0.1.6",
-        "figlet": "^1.10.0",
         "picocolors": "^1.1.1",
       },
       "devDependencies": {
         "@biomejs/biome": "^2.4.4",
         "@types/bun": "latest",
-        "@types/figlet": "^1.7.0",
         "typescript": "^5.7.0",
       },
     },
@@ -61,8 +59,6 @@
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
-    "@types/figlet": ["@types/figlet@1.7.0", "", {}, "sha512-KwrT7p/8Eo3Op/HBSIwGXOsTZKYiM9NpWRBJ5sVjWP/SmlS+oxxRvJht/FNAtliJvja44N3ul1yATgohnVBV0Q=="],
-
     "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
     "@wgtechlabs/log-engine": ["@wgtechlabs/log-engine@2.3.1", "", {}, "sha512-qYwGef4KjcWpFvfC/e6uum/Q2ICTJbaXBZf+qCDmho1rNZ/umqyeDH3Cvk86e2Jy5TkDFPA+rOcTkmrM1rGKkw=="],
@@ -71,11 +67,7 @@
 
     "citty": ["citty@0.1.6", "", { "dependencies": { "consola": "^3.2.3" } }, "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ=="],
 
-    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
     "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
-
-    "figlet": ["figlet@1.10.0", "", { "dependencies": { "commander": "^14.0.0" }, "bin": { "figlet": "bin/index.js" } }, "sha512-aktIwEZZ6Gp9AWdMXW4YCi0J2Ahuxo67fNJRUIWD81w8pQ0t9TS8FFpbl27ChlTLF06VkwjDesZSzEVzN75rzA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/landing/index.html
+++ b/landing/index.html
@@ -104,7 +104,7 @@
           </a>
         </div>
         <div class="hero-aliases">
-          <p class="hero-alias-note">Works as <code>contrib</code>, <code>contribute</code>, or <code>cn</code> — yes, <strong><code>cn</code> is shorter than <code>git</code></strong>. Your workflow just got faster to type. ⚡</p>
+          <p class="hero-alias-note">Works as <code>cn</code>, <code>contribute</code>, or <code>cn</code> — yes, <strong><code>cn</code> is shorter than <code>git</code></strong>. Your workflow just got faster to type. ⚡</p>
         </div>
         <div class="hero-badges">
           <span class="hero-badge hero-badge--license">
@@ -184,9 +184,9 @@
               <div class="terminal-dot dot-red"></div>
               <div class="terminal-dot dot-yellow"></div>
               <div class="terminal-dot dot-green"></div>
-              <div class="terminal-title">contrib sync</div>
+              <div class="terminal-title">cn sync</div>
             </div>
-            <div class="terminal-body"><span class="t-prompt">$</span> <span class="t-cmd">contrib sync</span>
+            <div class="terminal-body"><span class="t-prompt">$</span> <span class="t-cmd">cn sync</span>
 
 <span class="t-blue">ℹ</span> <span class="t-dim">Detecting workflow...</span> <span class="t-cmd">Clean Flow</span>
 <span class="t-blue">ℹ</span> <span class="t-dim">Detecting role...</span> <span class="t-cmd">Maintainer</span>
@@ -240,9 +240,9 @@
               <div class="terminal-dot dot-red"></div>
               <div class="terminal-dot dot-yellow"></div>
               <div class="terminal-dot dot-green"></div>
-              <div class="terminal-title">contrib commit</div>
+              <div class="terminal-title">cn commit</div>
             </div>
-            <div class="terminal-body"><span class="t-prompt">$</span> <span class="t-cmd">contrib commit</span>
+            <div class="terminal-body"><span class="t-prompt">$</span> <span class="t-cmd">cn commit</span>
 
 <span class="t-blue">ℹ</span> <span class="t-dim">Analyzing staged changes...</span>
 <span class="t-blue">ℹ</span> <span class="t-dim">Generating message with Copilot...</span>
@@ -299,9 +299,9 @@
               <div class="terminal-dot dot-red"></div>
               <div class="terminal-dot dot-yellow"></div>
               <div class="terminal-dot dot-green"></div>
-              <div class="terminal-title">contrib start</div>
+              <div class="terminal-title">cn start</div>
             </div>
-            <div class="terminal-body"><span class="t-prompt">$</span> <span class="t-cmd">contrib start <span class="t-green">"fix that annoying login bug"</span></span>
+            <div class="terminal-body"><span class="t-prompt">$</span> <span class="t-cmd">cn start <span class="t-green">"fix that annoying login bug"</span></span>
 
 <span class="t-blue">ℹ</span> <span class="t-dim">Asking Copilot for branch names...</span>
 
@@ -569,7 +569,7 @@ bunx contribute-now setup
 
 <span class="c-dim"># or install globally</span>
 bun install -g contribute-now
-cn setup  <span class="c-dim"># shorter than git! also: contrib, contribute</span></code></pre>
+cn setup  <span class="c-dim"># shorter than git! also: cn, contribute</span></code></pre>
               </div>
             </div>
           </div>
@@ -580,11 +580,11 @@ cn setup  <span class="c-dim"># shorter than git! also: contrib, contribute</spa
               <div class="code-block">
                 <div class="code-header">
                   <span class="code-lang">bash</span>
-                  <button class="copy-btn copy-code" data-code="contrib sync" title="Copy command">
+                  <button class="copy-btn copy-code" data-code="cn sync" title="Copy command">
                     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
                   </button>
                 </div>
-                <pre><code>contrib sync
+                <pre><code>cn sync
 <span class="c-dim"># ✓ updates your base branch (main/dev)
 # ✓ syncs with upstream automatically</span></code></pre>
               </div>

--- a/package.json
+++ b/package.json
@@ -49,13 +49,11 @@
     "@github/copilot-sdk": "^0.1.25",
     "@wgtechlabs/log-engine": "^2.3.1",
     "citty": "^0.1.6",
-    "figlet": "^1.10.0",
     "picocolors": "^1.1.1"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.4",
     "@types/bun": "latest",
-    "@types/figlet": "^1.7.0",
     "typescript": "^5.7.0"
   }
 }

--- a/scripts/_tmp_replace.mjs
+++ b/scripts/_tmp_replace.mjs
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const targets = [
+  'AGENTS.md',
+  'CONTRIBUTING.md',
+  'src/cli.ts',
+  'src/commands/clean.ts',
+  'src/commands/commit.ts',
+  'src/commands/config.ts',
+  'src/commands/discard.ts',
+  'src/commands/doctor.ts',
+  'src/commands/hook.ts',
+  'src/commands/log.ts',
+  'src/commands/save.ts',
+  'src/commands/start.ts',
+  'src/commands/status.ts',
+  'src/commands/submit.ts',
+  'src/commands/switch.ts',
+  'src/commands/sync.ts',
+  'src/commands/update.ts',
+  'src/commands/validate.ts',
+  'src/utils/copilot.ts',
+  'src/utils/workflow.ts',
+  'landing/index.html',
+];
+
+const SENTINEL = '__CONTRIB_SAVE_SENTINEL__';
+let total = 0;
+for (const rel of targets) {
+  const p = path.resolve(rel);
+  if (!fs.existsSync(p)) continue;
+  let src = fs.readFileSync(p, 'utf8');
+  const before = src;
+  src = src.replaceAll('contrib-save:', SENTINEL);
+  src = src.replace(/\bcontrib(?!ut)/g, 'cn');
+  src = src.replaceAll(SENTINEL, 'contrib-save:');
+  if (src !== before) {
+    fs.writeFileSync(p, src);
+    const count = (before.match(/\bcontrib(?!ut)/g) || []).length
+      - (before.match(/contrib-save:/g) || []).length;
+    console.log(`${rel}: ${count} replacements`);
+    total += count;
+  }
+}
+console.log(`\nTotal: ${total}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,4 +102,19 @@ const main = defineCommand({
   },
 });
 
-runMain(main);
+// Force a clean exit once the command finishes.
+//
+// Several dependencies keep Node's event loop alive after a command completes:
+//   - `@clack/prompts` leaves stdin in raw mode with listeners attached after prompts resolve
+//   - `@github/copilot-sdk` retains keep-alive HTTP sockets (and likely internal timers)
+//
+// Without an explicit exit, successful commands (`commit`, `switch`, `submit`, etc.) leave the
+// terminal hanging until the user hits Ctrl+C. Exiting here — after `runMain` has flushed
+// citty's own output — keeps the fix in one place instead of sprinkling `process.exit(0)`
+// across every command's success path.
+runMain(main)
+  .then(() => process.exit(process.exitCode ?? 0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -67,7 +67,7 @@ if (!isVersion) {
 
 const main = defineCommand({
   meta: {
-    name: 'contrib',
+    name: 'cn',
     version: getVersion(),
     description:
       'Git workflow CLI that guides contributors through clean branching, commits, and PRs.',
@@ -100,7 +100,7 @@ const main = defineCommand({
   },
   run({ args }) {
     if (args.version) {
-      console.log(`contrib v${getVersion()}`);
+      console.log(`cn v${getVersion()}`);
     }
   },
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,7 @@
 import { defineCommand, runMain } from 'citty';
 import branch from './commands/branch.js';
 import clean from './commands/clean.js';
+import discard from './commands/discard.js';
 import commit from './commands/commit.js';
 import config from './commands/config.js';
 import doctor from './commands/doctor.js';
@@ -48,6 +49,7 @@ if (!isVersion) {
     'update',
     'submit',
     'switch',
+    'discard',
     'save',
     'clean',
     'status',
@@ -86,6 +88,7 @@ const main = defineCommand({
     update,
     submit,
     switch: switchCmd,
+    discard,
     save,
     branch,
     clean,

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -159,7 +159,7 @@ export default defineCommand({
 
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 
@@ -304,7 +304,7 @@ export default defineCommand({
     if (finalBranch && protectedBranches.has(finalBranch)) {
       console.log();
       info(
-        `You're on ${pc.bold(finalBranch)}. Run ${pc.bold('contrib start')} to begin a new feature.`,
+        `You're on ${pc.bold(finalBranch)}. Run ${pc.bold('cn start')} to begin a new feature.`,
       );
     }
   },

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -289,7 +289,6 @@ export default defineCommand({
     }
 
     success(`Committed: ${pc.bold(finalMessage)}`);
-    process.exit(0);
   },
 });
 

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -289,6 +289,7 @@ export default defineCommand({
     }
 
     success(`Committed: ${pc.bold(finalMessage)}`);
+    process.exit(0);
   },
 });
 

--- a/src/commands/commit.ts
+++ b/src/commands/commit.ts
@@ -70,7 +70,7 @@ export default defineCommand({
 
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -478,13 +478,13 @@ export default defineCommand({
     await projectHeading('config', '⚙️');
 
     if (!configExists()) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 
     const config = readConfig();
     if (!config) {
-      error('Repo config exists but is invalid. Run `contrib setup` to repair it.');
+      error('Repo config exists but is invalid. Run `cn setup` to repair it.');
       process.exit(1);
     }
 
@@ -530,7 +530,7 @@ export default defineCommand({
 
     printConfigSummary(snapshot);
     console.log();
-    console.log(`  ${pc.dim('Run `contrib config --edit` to update these settings.')}`);
+    console.log(`  ${pc.dim('Run `cn config --edit` to update these settings.')}`);
     console.log();
   },
 });

--- a/src/commands/discard.ts
+++ b/src/commands/discard.ts
@@ -39,7 +39,7 @@ export default defineCommand({
 
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 
@@ -53,7 +53,7 @@ export default defineCommand({
       error(
         `${pc.bold(currentBranch)} is a protected branch and cannot be discarded.`,
       );
-      info(`Switch to a feature branch first, then run ${pc.bold('contrib discard')}.`);
+      info(`Switch to a feature branch first, then run ${pc.bold('cn discard')}.`);
       process.exit(1);
     }
 
@@ -107,7 +107,7 @@ export default defineCommand({
             error(`Failed to save changes: ${stashResult.stderr}`);
             process.exit(1);
           }
-          success(`Changes saved. Use ${pc.bold('contrib save --restore')} to bring them back.`);
+          success(`Changes saved. Use ${pc.bold('cn save --restore')} to bring them back.`);
         }
       }
     } else if (!args.force) {

--- a/src/commands/discard.ts
+++ b/src/commands/discard.ts
@@ -1,0 +1,160 @@
+import { defineCommand } from 'citty';
+import pc from 'picocolors';
+import { readConfig } from '../utils/config.js';
+import { confirmPrompt, selectPrompt } from '../utils/confirm.js';
+import {
+  assertCleanGitState,
+  checkoutBranch,
+  deleteRemoteBranch,
+  forceDeleteBranch,
+  getCurrentBranch,
+  getUpstreamRef,
+  hasLocalWork,
+  isGitRepo,
+  stashChanges,
+} from '../utils/git.js';
+import { error, info, projectHeading, success, warn } from '../utils/logger.js';
+import { getBaseBranch, isBranchProtected } from '../utils/workflow.js';
+
+export default defineCommand({
+  meta: {
+    name: 'discard',
+    description: 'Discard the current feature branch and return to the base branch',
+  },
+  args: {
+    force: {
+      type: 'boolean',
+      alias: 'f',
+      description: 'Skip confirmation and discard immediately',
+      default: false,
+    },
+  },
+  async run({ args }) {
+    if (!(await isGitRepo())) {
+      error('Not inside a git repository.');
+      process.exit(1);
+    }
+
+    await assertCleanGitState('discarding a branch');
+
+    const config = readConfig();
+    if (!config) {
+      error('No repo config found. Run `contrib setup` first.');
+      process.exit(1);
+    }
+
+    const currentBranch = await getCurrentBranch();
+    const baseBranch = getBaseBranch(config);
+
+    await projectHeading('discard', '🗑️');
+
+    // Guard: refuse to discard protected branches (main, dev, develop, etc.)
+    if (isBranchProtected(currentBranch, config)) {
+      error(
+        `${pc.bold(currentBranch)} is a protected branch and cannot be discarded.`,
+      );
+      info(`Switch to a feature branch first, then run ${pc.bold('contrib discard')}.`);
+      process.exit(1);
+    }
+
+    // Guard: already on the base branch
+    if (currentBranch === baseBranch) {
+      info(`You are already on ${pc.bold(baseBranch)}.`);
+      process.exit(0);
+    }
+
+    // Check for local work that would be lost
+    const { origin } = config;
+    const localWork = await hasLocalWork(origin, currentBranch);
+    const hasWork = localWork.uncommitted || localWork.unpushedCommits > 0;
+
+    if (hasWork) {
+      if (localWork.uncommitted) {
+        warn('You have uncommitted changes in your working tree.');
+      }
+      if (localWork.unpushedCommits > 0) {
+        warn(
+          `You have ${pc.bold(String(localWork.unpushedCommits))} unpushed commit${localWork.unpushedCommits !== 1 ? 's' : ''} on this branch.`,
+        );
+      }
+      warn('Discarding this branch will permanently lose that work.');
+
+      const SAVE_FIRST = 'Save my changes first (cn save), then discard';
+      const DISCARD_ANYWAY = 'Discard anyway — I do not need this work';
+      const CANCEL = 'Keep the branch, take me back';
+
+      const action = await selectPrompt(
+        'This branch has unsaved work. What would you like to do?',
+        [SAVE_FIRST, DISCARD_ANYWAY, CANCEL],
+      );
+
+      if (action === CANCEL) {
+        info('Discard cancelled. Your branch is untouched.');
+        process.exit(0);
+      }
+
+      if (action === SAVE_FIRST) {
+        if (!localWork.uncommitted) {
+          info('No uncommitted changes to stash — unpushed commits will still be lost.');
+          const confirm = await confirmPrompt('Continue discarding the branch?');
+          if (!confirm) {
+            info('Discard cancelled.');
+            process.exit(0);
+          }
+        } else {
+          const stashResult = await stashChanges(`work-in-progress on ${currentBranch}`);
+          if (stashResult.exitCode !== 0) {
+            error(`Failed to save changes: ${stashResult.stderr}`);
+            process.exit(1);
+          }
+          success(`Changes saved. Use ${pc.bold('contrib save --restore')} to bring them back.`);
+        }
+      }
+    } else if (!args.force) {
+      // No unsaved work — still confirm unless --force is passed
+      const confirmed = await confirmPrompt(
+        `Discard ${pc.bold(currentBranch)} and return to ${pc.bold(baseBranch)}?`,
+      );
+      if (!confirmed) {
+        info('Discard cancelled.');
+        process.exit(0);
+      }
+    }
+
+    // Check if there is a remote tracking branch to offer deletion
+    const upstreamRef = await getUpstreamRef();
+    let deleteRemote = false;
+    if (upstreamRef) {
+      deleteRemote = await confirmPrompt(
+        `Also delete the remote branch ${pc.bold(upstreamRef)}?`,
+      );
+    }
+
+    // Switch to base branch first
+    const checkoutResult = await checkoutBranch(baseBranch);
+    if (checkoutResult.exitCode !== 0) {
+      error(`Failed to switch to ${pc.bold(baseBranch)}: ${checkoutResult.stderr}`);
+      process.exit(1);
+    }
+
+    // Force-delete the feature branch locally
+    // (force-delete is required since the branch may not be merged)
+    const deleteResult = await forceDeleteBranch(currentBranch);
+    if (deleteResult.exitCode !== 0) {
+      error(`Failed to delete branch ${pc.bold(currentBranch)}: ${deleteResult.stderr}`);
+      process.exit(1);
+    }
+
+    success(`Discarded ${pc.bold(currentBranch)} and switched back to ${pc.bold(baseBranch)}`);
+
+    // Optionally delete remote branch
+    if (deleteRemote) {
+      const remoteDeleteResult = await deleteRemoteBranch(origin, currentBranch);
+      if (remoteDeleteResult.exitCode !== 0) {
+        warn(`Could not delete remote branch: ${remoteDeleteResult.stderr.trim()}`);
+      } else {
+        success(`Deleted remote branch ${pc.bold(`${origin}/${currentBranch}`)}`);
+      }
+    }
+  },
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -101,7 +101,7 @@ async function toolSection(): Promise<SectionReport> {
 
   // CLI version
   checks.push({
-    label: `contrib v${pkg.version ?? 'unknown'}`,
+    label: `cn v${pkg.version ?? 'unknown'}`,
     ok: true,
   });
 
@@ -172,7 +172,7 @@ async function configSection(): Promise<SectionReport> {
     checks.push({
       label: 'Repo config not found',
       ok: false,
-      detail: 'run `contrib setup` to create local config for this clone',
+      detail: 'run `cn setup` to create local config for this clone',
     });
 
     if (localStateLabel) {
@@ -257,7 +257,7 @@ async function configSection(): Promise<SectionReport> {
         warning: !hasApiKey,
         detail: hasSecretsStore()
           ? 'stored in the local secrets store'
-          : 'run `contrib setup` to save it',
+          : 'run `cn setup` to save it',
       });
     }
   }
@@ -392,7 +392,7 @@ async function workflowSection(): Promise<SectionReport> {
     checks.push({
       label: 'Cannot resolve workflow (no config)',
       ok: false,
-      detail: 'run `contrib setup` first',
+      detail: 'run `cn setup` first',
     });
     return { title: 'Workflow Resolution', checks };
   }

--- a/src/commands/hook.ts
+++ b/src/commands/hook.ts
@@ -19,14 +19,14 @@ function getHookPath(cwd = process.cwd()): string {
 
 /**
  * Generate the commit-msg hook script.
- * The hook calls `contrib validate` with the commit message file.
+ * The hook calls `cn validate` with the commit message file.
  */
 function generateHookScript(): string {
   return `#!/bin/sh
 ${HOOK_MARKER}
 # Validates commit messages against your configured convention.
-# Install:   contrib hook install
-# Uninstall: contrib hook uninstall
+# Install:   cn hook install
+# Uninstall: cn hook uninstall
 
 commit_msg_file="$1"
 commit_msg=$(head -1 "$commit_msg_file")
@@ -37,12 +37,12 @@ case "$commit_msg" in
 esac
 
 # Detect available package runner
-if command -v contrib >/dev/null 2>&1; then
-  contrib validate --file "$commit_msg_file"
+if command -v cn >/dev/null 2>&1; then
+  cn validate --file "$commit_msg_file"
 elif command -v bunx >/dev/null 2>&1; then
-  bunx contrib validate --file "$commit_msg_file"
+  bunx cn validate --file "$commit_msg_file"
 else
-  echo "Warning: Neither contrib nor bunx is available. Skipping commit message validation."
+  echo "Warning: Neither cn nor bunx is available. Skipping commit message validation."
   exit 0
 fi
 `;
@@ -85,13 +85,13 @@ async function installHook(): Promise<void> {
 
   const config = readConfig();
   if (!config) {
-    error('No repo config found. Run `contrib setup` first.');
+    error('No repo config found. Run `cn setup` first.');
     process.exit(1);
   }
 
   if (config.commitConvention === 'none') {
     warn('Commit convention is set to "none". No hook to install.');
-    info('Change your convention with `contrib setup` first.', '');
+    info('Change your convention with `cn setup` first.', '');
     process.exit(0);
   }
 

--- a/src/commands/log.ts
+++ b/src/commands/log.ts
@@ -130,7 +130,7 @@ export default defineCommand({
         console.log(pc.dim('    No upstream tracking set and no remote base branch found.'));
         console.log(
           pc.dim(
-            `    Use ${pc.bold('contrib log --full')} to see the full commit history instead.`,
+            `    Use ${pc.bold('cn log --full')} to see the full commit history instead.`,
           ),
         );
         console.log();

--- a/src/commands/save.ts
+++ b/src/commands/save.ts
@@ -95,7 +95,7 @@ async function handleSave(message?: string) {
   }
 
   success(`Saved: ${pc.dim(label)}`);
-  info(`Use ${pc.bold('contrib save --restore')} to bring them back.`, '');
+  info(`Use ${pc.bold('cn save --restore')} to bring them back.`, '');
 }
 
 // ── Restore ──
@@ -151,8 +151,8 @@ async function handleList() {
     console.log(`  ${idx}  ${msg}`);
   }
   console.log();
-  info(`Use ${pc.bold('contrib save --restore')} to bring changes back.`, '');
-  info(`Use ${pc.bold('contrib save --drop')} to discard saved changes.`, '');
+  info(`Use ${pc.bold('cn save --restore')} to bring changes back.`, '');
+  info(`Use ${pc.bold('cn save --drop')} to discard saved changes.`, '');
 }
 
 // ── Drop ──

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -49,7 +49,7 @@ export default defineCommand({
 
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -37,7 +37,7 @@ export default defineCommand({
 
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 

--- a/src/commands/submit.ts
+++ b/src/commands/submit.ts
@@ -134,7 +134,7 @@ async function performSquashMerge(
     }
   }
 
-  // Let user accept / edit / regenerate / write manually (same as contrib commit)
+  // Let user accept / edit / regenerate / write manually (same as cn commit)
   let finalMsg: string | null = null;
   if (message) {
     while (!finalMsg) {
@@ -210,7 +210,7 @@ async function performSquashMerge(
   }
 
   success(`Squash merged ${pc.bold(featureBranch)} into ${pc.bold(baseBranch)} and pushed.`);
-  info(`Run ${pc.bold('contrib start')} to begin a new feature.`, '');
+  info(`Run ${pc.bold('cn start')} to begin a new feature.`, '');
 }
 
 export default defineCommand({
@@ -257,7 +257,7 @@ export default defineCommand({
 
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 
@@ -289,7 +289,7 @@ export default defineCommand({
 
       if (!hasAnything) {
         error('No local changes or commits to move. Switch to a feature branch first.');
-        info(`  Run ${pc.bold('contrib start')} to create a new feature branch.`, '');
+        info(`  Run ${pc.bold('cn start')} to create a new feature branch.`, '');
         process.exit(1);
       }
 
@@ -345,7 +345,7 @@ export default defineCommand({
 
       console.log();
       success(`You're now on ${pc.bold(newBranchName)} with all your work intact.`);
-      info(`Run ${pc.bold('contrib submit')} again to push and create your PR.`, '');
+      info(`Run ${pc.bold('cn submit')} again to push and create your PR.`, '');
       return;
     }
 
@@ -443,7 +443,7 @@ export default defineCommand({
             }
 
             info(
-              `All your changes are preserved. Run ${pc.bold('contrib submit')} when ready to create a new PR.`,
+              `All your changes are preserved. Run ${pc.bold('cn submit')} when ready to create a new PR.`,
               '',
             );
             return;
@@ -477,7 +477,7 @@ export default defineCommand({
 
         console.log();
         info(
-          `You're now on ${pc.bold(baseBranch)}. Run ${pc.bold('contrib start')} to begin a new feature.`,
+          `You're now on ${pc.bold(baseBranch)}. Run ${pc.bold('cn start')} to begin a new feature.`,
         );
         return;
       }
@@ -501,7 +501,7 @@ export default defineCommand({
           ) {
             warn('The remote branch has diverged. Try:');
             info(`  git pull --rebase ${origin} ${currentBranch}`, '');
-            info('  Then run `contrib submit` again.', '');
+            info('  Then run `cn submit` again.', '');
           }
           process.exit(1);
         }
@@ -694,7 +694,7 @@ export default defineCommand({
       ) {
         warn('The remote branch has diverged. Try:');
         info(`  git pull --rebase ${origin} ${currentBranch}`, '');
-        info('  Then run `contrib submit` again.', '');
+        info('  Then run `cn submit` again.', '');
         info('If you need to force push (use with caution):', '');
         info(`  git push --force-with-lease ${origin} ${currentBranch}`, '');
       }

--- a/src/commands/switch.ts
+++ b/src/commands/switch.ts
@@ -111,14 +111,14 @@ export default defineCommand({
           await exec('git', ['stash', 'pop']);
           info('Restored saved changes.');
         } catch {
-          warn('Could not restore save automatically. Use `contrib save --restore` to recover.');
+          warn('Could not restore save automatically. Use `cn save --restore` to recover.');
         }
         process.exit(1);
       }
 
       success(`Switched to ${pc.bold(targetBranch)}`);
       info(`Your changes from ${pc.bold(currentBranch ?? 'previous branch')} are saved.`, '');
-      info(`Use ${pc.bold('contrib save --restore')} to bring them back.`, '');
+      info(`Use ${pc.bold('cn save --restore')} to bring them back.`, '');
       return;
     }
 

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -60,7 +60,7 @@ export default defineCommand({
 
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 
@@ -95,7 +95,7 @@ export default defineCommand({
       error(`Remote ref ${pc.bold(syncSource.ref)} does not exist.`);
       info('This can happen if the branch was renamed or deleted on the remote.', '');
       info(
-        `Check your config: the base branch may need updating via ${pc.bold('contrib setup')}.`,
+        `Check your config: the base branch may need updating via ${pc.bold('cn setup')}.`,
         '',
       );
       process.exit(1);
@@ -176,7 +176,7 @@ export default defineCommand({
           console.log();
           info(`Your commits are safe on ${pc.bold(newBranchName)}.`, '');
           info(
-            `Run ${pc.bold(`git checkout ${newBranchName}`)} then ${pc.bold('contrib update')} to rebase onto the synced ${pc.bold(baseBranch)}.`,
+            `Run ${pc.bold(`git checkout ${newBranchName}`)} then ${pc.bold('cn update')} to rebase onto the synced ${pc.bold(baseBranch)}.`,
             '',
           );
           return;
@@ -212,7 +212,7 @@ export default defineCommand({
       } else {
         error(`Fast-forward pull failed. Your local ${pc.bold(baseBranch)} may have diverged.`);
         info(
-          `Use ${pc.bold('contrib sync')} again and choose "Move my commits to a new feature branch" to fix this.`,
+          `Use ${pc.bold('cn sync')} again and choose "Move my commits to a new feature branch" to fix this.`,
           '',
         );
       }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -69,7 +69,7 @@ export default defineCommand({
 
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 
@@ -102,7 +102,7 @@ export default defineCommand({
       if (!hasAnything) {
         info(`No local changes found on ${pc.bold(currentBranch)}.`);
         info(
-          `Use ${pc.bold('contrib sync')} to sync protected branches, or ${pc.bold('contrib start')} to create a feature branch.`,
+          `Use ${pc.bold('cn sync')} to sync protected branches, or ${pc.bold('cn start')} to create a feature branch.`,
         );
         process.exit(1);
       }
@@ -158,7 +158,7 @@ export default defineCommand({
       console.log();
       success(`You're now on ${pc.bold(newBranchName)} with all your work intact.`);
       info(
-        `Run ${pc.bold('contrib update')} again to rebase onto latest ${pc.bold(baseBranch)}.`,
+        `Run ${pc.bold('cn update')} again to rebase onto latest ${pc.bold(baseBranch)}.`,
         '',
       );
       return;
@@ -262,7 +262,7 @@ export default defineCommand({
           }
 
           info(
-            `All your changes are preserved. Run ${pc.bold('contrib submit')} when ready to create a new PR.`,
+            `All your changes are preserved. Run ${pc.bold('cn submit')} when ready to create a new PR.`,
             '',
           );
           return;
@@ -295,7 +295,7 @@ export default defineCommand({
       await forceDeleteBranch(currentBranch);
       success(`Deleted ${pc.bold(currentBranch)}.`);
 
-      info(`Run ${pc.bold('contrib start')} to begin a new feature branch.`, '');
+      info(`Run ${pc.bold('cn start')} to begin a new feature branch.`, '');
       return;
     }
 

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -28,7 +28,7 @@ export default defineCommand({
   async run({ args }) {
     const config = readConfig();
     if (!config) {
-      error('No repo config found. Run `contrib setup` first.');
+      error('No repo config found. Run `cn setup` first.');
       process.exit(1);
     }
 

--- a/src/data/announcements.json
+++ b/src/data/announcements.json
@@ -5,5 +5,12 @@
     "title": "Legacy Config Detected",
     "message": "Run cn setup to migrate this clone to local Git config, then delete .contributerc.json.",
     "when": "legacy-config-present"
+  },
+  {
+    "id": "contrib-command-deprecation",
+    "kind": "info",
+    "title": "Heads up: `contrib` will retire",
+    "message": "The `contrib` command is being phased out. Please switch to `contribute` (primary) or the shorter `cn` shortcut — same features either way.",
+    "when": "contrib-command-used"
   }
 ]

--- a/src/ui/banner.ts
+++ b/src/ui/banner.ts
@@ -1,4 +1,3 @@
-import figlet from 'figlet';
 import pc from 'picocolors';
 import pkg from '../../package.json';
 import {
@@ -7,19 +6,23 @@ import {
   getActiveAnnouncements,
 } from '../utils/announcements.js';
 
-let LOGO_BIG: string;
-try {
-  LOGO_BIG = figlet.textSync('Contribute\nNow', { font: 'ANSI Shadow' });
-} catch {
-  LOGO_BIG = 'Contribute Now';
-}
-
-let LOGO_SMALL: string;
-try {
-  LOGO_SMALL = figlet.textSync('Contribute Now', { font: 'Slant' });
-} catch {
-  LOGO_SMALL = 'Contribute Now';
-}
+// Pre-rendered ASCII banner.
+//
+// Previously generated at runtime with `figlet`, but bundled builds can't
+// reliably locate figlet's font files, which caused the banner to silently
+// fall back to plain text after `npm install -g`. Baking the output here
+// removes the runtime font-loading fragility and drops the figlet dep.
+//
+// Source:
+//   figlet.textSync('Contribute Now', { font: 'Slant' })
+//
+// `String.raw` preserves backslashes in the art exactly as-is.
+const LOGO = String.raw`   ______            __       _ __          __          _   __             
+  / ____/___  ____  / /______(_) /_  __  __/ /____     / | / /___ _      __
+ / /   / __ \/ __ \/ __/ ___/ / __ \/ / / / __/ _ \   /  |/ / __ \ | /| / /
+/ /___/ /_/ / / / / /_/ /  / / /_/ / /_/ / /_/  __/  / /|  / /_/ / |/ |/ / 
+\____/\____/_/ /_/\__/_/  /_/_.___/\__,_/\__/\___/  /_/ |_/\____/|__/|__/  
+                                                                           `;
 
 export function getVersion(): string {
   return pkg.version ?? 'unknown';
@@ -30,8 +33,7 @@ export function getAuthor(): string {
 }
 
 export function showBanner(variant: 'big' | 'small' = 'small'): void {
-  const logo = variant === 'big' ? LOGO_BIG : LOGO_SMALL;
-  console.log(pc.cyan(`\n${logo}`));
+  console.log(pc.cyan(`\n${LOGO}`));
   console.log(
     `  ${pc.dim(`v${getVersion()}`)} ${pc.dim('—')} ${pc.dim(`Built by ${getAuthor()}`)}`,
   );

--- a/src/utils/announcements.ts
+++ b/src/utils/announcements.ts
@@ -2,7 +2,7 @@ import announcements from '../data/announcements.json';
 import { hasLegacyConfig } from './config.js';
 
 export type AnnouncementKind = 'info' | 'notice' | 'warning';
-type AnnouncementCondition = 'legacy-config-present';
+type AnnouncementCondition = 'legacy-config-present' | 'contrib-command-used';
 
 interface AnnouncementDefinition {
   id: string;
@@ -35,7 +35,25 @@ function shouldShowAnnouncement(announcement: AnnouncementDefinition, cwd: strin
   switch (announcement.when) {
     case 'legacy-config-present':
       return hasLegacyConfig(cwd);
+    case 'contrib-command-used':
+      return isLegacyCommandInvocation();
     default:
       return false;
   }
+}
+
+/**
+ * Detects whether the CLI was invoked via the legacy `contrib` binary name.
+ * Only `contrib` is being phased out — `contribute` remains the primary
+ * command and `cn` is the preferred shortcut.
+ *
+ * argv[1] is the script path; we inspect its basename (without extension)
+ * so packaged shims like `contrib.cmd` on Windows still match.
+ */
+function isLegacyCommandInvocation(): boolean {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  const basename = entry.split(/[\\/]/).pop() ?? '';
+  const name = basename.replace(/\.(cmd|exe|ps1|bat|js|mjs|cjs)$/i, '').toLowerCase();
+  return name === 'contrib';
 }

--- a/src/utils/copilot.ts
+++ b/src/utils/copilot.ts
@@ -442,13 +442,13 @@ export async function checkCopilotAvailable(): Promise<string | null> {
   const aiConfig = resolveAIConfig();
   if (aiConfig.provider === 'ollama-cloud') {
     if (!(await hasOllamaCloudApiKey())) {
-      return 'Ollama Cloud API key not found. Run `contrib setup` to save it.';
+      return 'Ollama Cloud API key not found. Run `cn setup` to save it.';
     }
 
     try {
       const apiKey = await getOllamaCloudApiKey();
       if (!apiKey) {
-        return 'Ollama Cloud API key not found. Run `contrib setup` to save it.';
+        return 'Ollama Cloud API key not found. Run `cn setup` to save it.';
       }
 
       await fetchOllamaCloudModels(apiKey, aiConfig.host);
@@ -456,7 +456,7 @@ export async function checkCopilotAvailable(): Promise<string | null> {
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg === 'Ollama Cloud authentication failed') {
-        return 'Ollama Cloud authentication failed. Update your saved API key with `contrib setup`.';
+        return 'Ollama Cloud authentication failed. Update your saved API key with `cn setup`.';
       }
       if (msg.startsWith('Ollama Cloud model lookup failed')) {
         return msg.replace('model lookup', 'health check');

--- a/src/utils/git.ts
+++ b/src/utils/git.ts
@@ -478,6 +478,14 @@ export async function deleteRemoteBranch(remote: string, branch: string): Promis
   return run(['push', remote, '--delete', branch]);
 }
 
+/**
+ * Stash uncommitted changes with an optional message.
+ * Uses the same `contrib-save:` prefix as `cn save` so stashes are consistent.
+ */
+export async function stashChanges(message: string): Promise<GitResult> {
+  return run(['stash', 'push', '-m', `contrib-save: ${message}`]);
+}
+
 export async function mergeSquash(branch: string): Promise<GitResult> {
   return run(['merge', '--squash', branch]);
 }

--- a/src/utils/workflow.ts
+++ b/src/utils/workflow.ts
@@ -94,7 +94,7 @@ export function getProtectedBranches(config: ContributeConfig): string[] {
 /**
  * Returns prefixes for branches that are protected in the given workflow.
  * For git-flow, release/* and hotfix/* branches are semantically protected
- * and should not be deleted by `contrib clean`.
+ * and should not be deleted by `cn clean`.
  */
 export function getProtectedPrefixes(config: ContributeConfig): string[] {
   if (config.workflow === 'git-flow') {


### PR DESCRIPTION
This pull request standardizes the CLI command references throughout the documentation, landing page, and scripts by replacing most uses of the `contrib` alias with `cn` (the new preferred short alias) or `contribute` (the primary command). It also removes the unused `figlet` dependency, updates workflow configuration, and adds a script to automate these replacements. These changes improve clarity for users and prepare for the deprecation of the old `contrib` alias.

**Command alias standardization:**

* Replaced nearly all references to the `contrib` CLI alias with `cn` or `contribute` in `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, and `landing/index.html`. Updated documentation to clarify that `contribute` is now the primary command and `cn` is the preferred short alias, with `contrib` being phased out. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R54) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R85) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L93-R101) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L110-R139) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L146-R236) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L367-R370) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L382-R385) [[9]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3L107-R107) [[10]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3L187-R189) [[11]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3L243-R245) [[12]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3L302-R304) [[13]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3L572-R572) [[14]](diffhunk://#diff-e96b748cf2f0f1f9095d43f2376aa8b671367d15278726144bcc04344fe619d3L583-R587) [[15]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L44-R51) [[16]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L47-R47)

* Updated documentation and user-facing examples to consistently use `cn` for commands and clarified the status of each alias. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L47-R54) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R85)

**Dependency and workflow updates:**

* Removed the unused `figlet` package and its type definitions from `package.json` to clean up dependencies.

* Updated the GitHub Actions workflow in `.github/workflows/package.yml` for improved quoting and added `package-scope` configuration.

**Automation and branding:**

* Added a utility script `scripts/_tmp_replace.mjs` to automate the replacement of the `contrib` alias with `cn` across key files, while preserving certain namespace references.

* Updated the contributors badge image URL to use the new `cn.rocks` domain for branding consistency.

These changes ensure users are guided toward the new command aliases and reduce confusion as the project transitions away from the legacy `contrib` alias.