### PR TITLE
🔧 update (setup): reuse stored AI keys during setup

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -302,13 +302,20 @@ export default defineCommand({
       }
 
       if (aiProvider === 'ollama-cloud') {
-        const resolvedKey = await resolveApiKeyForSetup({
-          providerLabel: 'Ollama Cloud',
-          hasStoredKey: await hasOllamaCloudApiKey(),
-          getStoredKey: getOllamaCloudApiKey,
-          select: selectPrompt,
-          promptSecret: passwordPrompt,
-        });
+        let resolvedKey: SetupApiKeyResolution;
+        try {
+          resolvedKey = await resolveApiKeyForSetup({
+            providerLabel: 'Ollama Cloud',
+            hasStoredKey: await hasOllamaCloudApiKey(),
+            getStoredKey: getOllamaCloudApiKey,
+            select: selectPrompt,
+            promptSecret: passwordPrompt,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          error(message);
+          process.exit(1);
+        }
 
         aiModel = await promptForOllamaCloudModel(resolvedKey.apiKey);
 
@@ -326,13 +333,20 @@ export default defineCommand({
           process.exit(1);
         }
       } else if (aiProvider === 'openrouter') {
-        const resolvedKey = await resolveApiKeyForSetup({
-          providerLabel: 'OpenRouter',
-          hasStoredKey: await hasOpenRouterApiKey(),
-          getStoredKey: getOpenRouterApiKey,
-          select: selectPrompt,
-          promptSecret: passwordPrompt,
-        });
+        let resolvedKey: SetupApiKeyResolution;
+        try {
+          resolvedKey = await resolveApiKeyForSetup({
+            providerLabel: 'OpenRouter',
+            hasStoredKey: await hasOpenRouterApiKey(),
+            getStoredKey: getOpenRouterApiKey,
+            select: selectPrompt,
+            promptSecret: passwordPrompt,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          error(message);
+          process.exit(1);
+        }
 
         aiModel = await promptForOpenRouterModel(resolvedKey.apiKey);
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -40,7 +40,11 @@ import {
 import { error, info, projectHeading, success, warn } from '../utils/logger.js';
 import { parseRepoFromUrl } from '../utils/remote.js';
 import {
+  getOllamaCloudApiKey,
+  getOpenRouterApiKey,
   getSecretsStorePath,
+  hasOllamaCloudApiKey,
+  hasOpenRouterApiKey,
   setOllamaCloudApiKey,
   setOpenRouterApiKey,
 } from '../utils/secrets.js';
@@ -85,6 +89,66 @@ export async function shouldContinueSetupWithExistingConfig(
   }
 
   return true;
+}
+
+export interface SetupApiKeyResolutionOptions {
+  providerLabel: 'Ollama Cloud' | 'OpenRouter';
+  hasStoredKey: boolean;
+  getStoredKey: () => Promise<string | null>;
+  select: (message: string, options: string[]) => Promise<string>;
+  promptSecret: (message: string) => Promise<string>;
+}
+
+export interface SetupApiKeyResolution {
+  apiKey: string;
+  shouldStore: boolean;
+  reusedStoredKey: boolean;
+}
+
+export async function resolveApiKeyForSetup(
+  options: SetupApiKeyResolutionOptions,
+): Promise<SetupApiKeyResolution> {
+  const { providerLabel, hasStoredKey, getStoredKey, select, promptSecret } = options;
+
+  if (hasStoredKey) {
+    const choice = await select(`${providerLabel} API key`, [
+      'Keep existing stored key',
+      'Replace stored key',
+    ]);
+
+    if (choice === 'Keep existing stored key') {
+      const existing = (await getStoredKey())?.trim() || '';
+      if (existing) {
+        return {
+          apiKey: existing,
+          shouldStore: false,
+          reusedStoredKey: true,
+        };
+      }
+    }
+
+    const replacement = (await promptSecret(`Enter your ${providerLabel} API key`)).trim();
+    if (!replacement) {
+      throw new Error(`${providerLabel} API key is required when ${providerLabel} is selected.`);
+    }
+
+    return {
+      apiKey: replacement,
+      shouldStore: true,
+      reusedStoredKey: false,
+    };
+  }
+
+  const initial = (await promptSecret(`Enter your ${providerLabel} API key`)).trim();
+  if (!initial) {
+    throw new Error(`${providerLabel} API key is required when ${providerLabel} is selected.`);
+  }
+
+  return {
+    apiKey: initial,
+    shouldStore: true,
+    reusedStoredKey: false,
+  };
 }
 
 async function promptForOllamaCloudModel(
@@ -238,36 +302,48 @@ export default defineCommand({
       }
 
       if (aiProvider === 'ollama-cloud') {
-        const apiKey = (await passwordPrompt('Enter your Ollama Cloud API key')).trim();
-        if (!apiKey) {
-          error('Ollama Cloud API key is required when Ollama Cloud is selected.');
-          process.exit(1);
-        }
+        const resolvedKey = await resolveApiKeyForSetup({
+          providerLabel: 'Ollama Cloud',
+          hasStoredKey: await hasOllamaCloudApiKey(),
+          getStoredKey: getOllamaCloudApiKey,
+          select: selectPrompt,
+          promptSecret: passwordPrompt,
+        });
 
-        aiModel = await promptForOllamaCloudModel(apiKey);
+        aiModel = await promptForOllamaCloudModel(resolvedKey.apiKey);
 
         try {
-          await setOllamaCloudApiKey(apiKey);
-          success('Stored Ollama Cloud API key in the local secrets store.');
-          info(`Secrets path: ${pc.bold(getSecretsStorePath())}`);
+          if (resolvedKey.shouldStore) {
+            await setOllamaCloudApiKey(resolvedKey.apiKey);
+            success('Stored Ollama Cloud API key in the local secrets store.');
+            info(`Secrets path: ${pc.bold(getSecretsStorePath())}`);
+          } else {
+            info('Using existing Ollama Cloud API key from the local secrets store.');
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           error(`Failed to store Ollama Cloud API key: ${message}`);
           process.exit(1);
         }
       } else if (aiProvider === 'openrouter') {
-        const apiKey = (await passwordPrompt('Enter your OpenRouter API key')).trim();
-        if (!apiKey) {
-          error('OpenRouter API key is required when OpenRouter is selected.');
-          process.exit(1);
-        }
+        const resolvedKey = await resolveApiKeyForSetup({
+          providerLabel: 'OpenRouter',
+          hasStoredKey: await hasOpenRouterApiKey(),
+          getStoredKey: getOpenRouterApiKey,
+          select: selectPrompt,
+          promptSecret: passwordPrompt,
+        });
 
-        aiModel = await promptForOpenRouterModel(apiKey);
+        aiModel = await promptForOpenRouterModel(resolvedKey.apiKey);
 
         try {
-          await setOpenRouterApiKey(apiKey);
-          success('Stored OpenRouter API key in the local secrets store.');
-          info(`Secrets path: ${pc.bold(getSecretsStorePath())}`);
+          if (resolvedKey.shouldStore) {
+            await setOpenRouterApiKey(resolvedKey.apiKey);
+            success('Stored OpenRouter API key in the local secrets store.');
+            info(`Secrets path: ${pc.bold(getSecretsStorePath())}`);
+          } else {
+            info('Using existing OpenRouter API key from the local secrets store.');
+          }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           error(`Failed to store OpenRouter API key: ${message}`);

--- a/tests/commands/setup.test.ts
+++ b/tests/commands/setup.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { shouldContinueSetupWithExistingConfig } from '../../src/commands/setup.js';
+import {
+  resolveApiKeyForSetup,
+  shouldContinueSetupWithExistingConfig,
+} from '../../src/commands/setup.js';
 import type { ContributeConfig } from '../../src/types.js';
 
 function sampleConfig(): ContributeConfig {
@@ -97,5 +100,49 @@ describe('setup existing config gate', () => {
     });
 
     expect(shouldContinue).toBe(true);
+  });
+});
+
+describe('setup API key resolution', () => {
+  it('reuses stored key when keep is selected', async () => {
+    const result = await resolveApiKeyForSetup({
+      providerLabel: 'OpenRouter',
+      hasStoredKey: true,
+      getStoredKey: async () => 'stored-secret',
+      select: async () => 'Keep existing stored key',
+      promptSecret: async () => 'should-not-be-used',
+    });
+
+    expect(result.apiKey).toBe('stored-secret');
+    expect(result.shouldStore).toBe(false);
+    expect(result.reusedStoredKey).toBe(true);
+  });
+
+  it('prompts for replacement when keep is selected but stored key is missing', async () => {
+    const result = await resolveApiKeyForSetup({
+      providerLabel: 'Ollama Cloud',
+      hasStoredKey: true,
+      getStoredKey: async () => null,
+      select: async () => 'Keep existing stored key',
+      promptSecret: async () => 'new-secret',
+    });
+
+    expect(result.apiKey).toBe('new-secret');
+    expect(result.shouldStore).toBe(true);
+    expect(result.reusedStoredKey).toBe(false);
+  });
+
+  it('prompts for initial key when no stored key exists', async () => {
+    const result = await resolveApiKeyForSetup({
+      providerLabel: 'OpenRouter',
+      hasStoredKey: false,
+      getStoredKey: async () => null,
+      select: async () => 'Keep existing stored key',
+      promptSecret: async () => 'first-secret',
+    });
+
+    expect(result.apiKey).toBe('first-secret');
+    expect(result.shouldStore).toBe(true);
+    expect(result.reusedStoredKey).toBe(false);
   });
 });

--- a/tests/commands/setup.test.ts
+++ b/tests/commands/setup.test.ts
@@ -145,4 +145,30 @@ describe('setup API key resolution', () => {
     expect(result.shouldStore).toBe(true);
     expect(result.reusedStoredKey).toBe(false);
   });
+
+  it('prompts for replacement when replace is selected', async () => {
+    const result = await resolveApiKeyForSetup({
+      providerLabel: 'OpenRouter',
+      hasStoredKey: true,
+      getStoredKey: async () => 'stored-secret',
+      select: async () => 'Replace stored key',
+      promptSecret: async () => 'replacement-secret',
+    });
+
+    expect(result.apiKey).toBe('replacement-secret');
+    expect(result.shouldStore).toBe(true);
+    expect(result.reusedStoredKey).toBe(false);
+  });
+
+  it('throws validation error when replacement key is empty', async () => {
+    await expect(
+      resolveApiKeyForSetup({
+        providerLabel: 'Ollama Cloud',
+        hasStoredKey: true,
+        getStoredKey: async () => 'stored-secret',
+        select: async () => 'Replace stored key',
+        promptSecret: async () => '   ',
+      }),
+    ).rejects.toThrow('Ollama Cloud API key is required when Ollama Cloud is selected.');
+  });
 });


### PR DESCRIPTION
## Summary
- update setup flow to reuse existing stored Ollama/OpenRouter API keys
- add keep/replace key choice during setup instead of always re-prompting
- preserve model selection behavior while reducing repeated secret entry
- add unit tests for setup API key resolution paths

## Validation
- bun test tests/commands/setup.test.ts tests/commands/config.test.ts tests/utils/config.test.ts