### PR TITLE
🔧 update: switch build target to Node and import Copilot availability check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ bun install
 
 ```bash
 # Run the CLI locally
-bun src/index.ts --help
+bun src/cli.ts --help
 
 # Build for production
 bun run build
@@ -35,7 +35,7 @@ bun run lint
 bun run lint:fix
 ```
 
-`contribute-now` runs on Bun at runtime. Use `bunx contribute-now ...` for one-off local testing, or use `bun link` if you want the `contribute-now` command available globally while working on local edits. `bun install -g contribute-now` installs the published package from the registry, so it will not reflect your local changes.
+The packaged CLI runs on Node.js (22, 24, or 26). Bun remains the toolchain for local development, builds, and tests. Use `bunx contribute-now ...` for one-off local testing, or use `bun link` if you want the `contribute-now` command available globally while working on local edits. `npm install -g contribute-now` installs the published package from the registry, so it will not reflect your local changes.
 
 ## Development Workflow
 
@@ -162,7 +162,7 @@ When contributing code, please:
 - A clear, descriptive title.
 - Steps to reproduce the issue.
 - Expected vs. actual behavior.
-- Your environment (OS, Bun version, Git version).
+- Your environment (OS, Node.js version, Bun version, Git version).
 - Relevant logs or error messages.
 
 Please search [existing issues](https://github.com/warengonzaga/contribute-now/issues) first to avoid duplicates.

--- a/README.md
+++ b/README.md
@@ -38,17 +38,19 @@ contribute-now validates commit messages and guides your AI toward the right for
 ## Quick Start
 
 ```bash
+ npx contribute-now setup
+# or
 bunx contribute-now setup
 ```
 
 Or install globally:
 
 ```bash
-bun install -g contribute-now
+npm install -g contribute-now
 contribute setup
 ```
 
-`contribute-now` now runs on Bun at runtime. Use `bunx` for one-off execution and `bun install -g` for a global install.
+`contribute-now` runs on Node.js at runtime. Node.js 26 is the default target, with Node.js 22 and 24 LTS also supported. Bun remains the toolchain for local development, builds, tests, and `bunx` workflows.
 
 > `contribute` is the primary command; `cn` is the short alias for the same binary — use whichever you prefer.
 >
@@ -61,18 +63,20 @@ contribute setup
 ## Installation
 
 ```bash
-# one-off
+# one-off under Node.js
+npx contribute-now setup
+
+# one-off with Bun toolchain
 bunx contribute-now setup
 
 # global
-bun install -g contribute-now
+npm install -g contribute-now
 ```
 
-If you prefer to install the package from npm, install Bun first and then install `contribute-now`:
+If you prefer Bun for installation, the packaged CLI still runs on Node.js after install:
 
 ```bash
-npm install -g bun
-npm install -g contribute-now
+bun install -g contribute-now
 ```
 
 Once installed, you can use either alias:
@@ -86,6 +90,7 @@ cn setup          # short alias — even shorter than git!
 
 ## Prerequisites
 
+- **[Node.js](https://nodejs.org/)** — runtime target is Node.js 26 by default; Node.js 22 and 24 LTS are also supported
 - **[Git](https://git-scm.com/)** — required
 - **[GitHub CLI](https://cli.github.com)** (`gh`) — recommended; required for PR creation, role detection, and merge status checks
 - **[GitHub Copilot](https://github.com/features/copilot)** — optional; one of the supported AI providers
@@ -239,7 +244,7 @@ cn doctor --json   # machine-readable JSON output
 ```
 
 Checks include:
-- CLI version and runtime (Bun)
+- CLI version, active runtime, and Node.js runtime policy
 - git and GitHub CLI availability and authentication
 - active repo config validity and storage location
 - Git repo state (uncommitted changes, lock files, shallow clone)
@@ -472,12 +477,12 @@ git clone https://github.com/warengonzaga/contribute-now.git
 cd contribute-now
 bun install
 
-bun run build   # compile to dist/index.js
+bun run build   # compile to dist/cli.js
 bun test        # run tests
 bun run lint    # check code quality
 ```
 
-The CLI is Bun-first end to end: local development, tests, packaged runtime, and one-off execution all assume Bun.
+Bun powers local development, build, and test workflows. The packaged CLI runs on Node.js 22, 24, or 26, with Node.js 26 as the default runtime target.
 
 ## 🎯 Contributing
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ contribute-now validates commit messages and guides your AI toward the right for
 ## Quick Start
 
 ```bash
- npx contribute-now setup
+npx contribute-now setup
 # or
 bunx contribute-now setup
 ```

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "build": "bun build src/cli.ts --outfile dist/cli.js --target node && bun run scripts/add-shebang.mjs",
-    "cli": "bun run src/cli.ts --",
+    "cli": "node dist/cli.js",
     "dev": "bun src/cli.ts",
     "test": "bun test",
     "lint": "biome check .",
@@ -25,6 +25,7 @@
     "landing:preview": "bun run --cwd landing preview"
   },
   "engines": {
+    "node": ">=22 <27",
     "bun": ">=1.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "landing:preview": "bun run --cwd landing preview"
   },
   "engines": {
-    "node": ">=22 <27",
+    "node": ">=22 <23 || >=24 <25 || >=26 <27",
     "bun": ">=1.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "bun build src/cli.ts --outfile dist/cli.js --target bun && bun run scripts/add-shebang.mjs",
+    "build": "bun build src/cli.ts --outfile dist/cli.js --target node && bun run scripts/add-shebang.mjs",
     "cli": "bun run src/cli.ts --",
     "dev": "bun src/cli.ts",
     "test": "bun test",

--- a/scripts/add-shebang.mjs
+++ b/scripts/add-shebang.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 const scriptDir = path.dirname(fileURLToPath(import.meta.url));
 const filePath = path.resolve(scriptDir, '../dist/cli.js');
-const shebang = '#!/usr/bin/env bun\n';
+const shebang = '#!/usr/bin/env node\n';
 
 if (!fs.existsSync(filePath)) {
   throw new Error(`Build output not found: ${filePath}. Run the build before adding the shebang.`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -172,8 +172,6 @@ function normalizeCliArgs(argv: string[]): string[] {
 
 process.argv = normalizeCliArgs(process.argv);
 
-ensureSupportedRuntime();
-
 const isVersion = process.argv.includes('--version') || process.argv.includes('-v');
 const subCommands = Object.keys(CLI_SUBCOMMANDS);
 const isHelp = process.argv.includes('--help') || process.argv.includes('-h');
@@ -194,6 +192,10 @@ if (isRootHelp) {
 if (isHelp && requestedSubCommand) {
   showCompactSubCommandHelp(requestedSubCommand);
   process.exit(0);
+}
+
+if (!isVersion && !isHelp) {
+  ensureSupportedRuntime();
 }
 
 const main = defineCommand({

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ import sync from './commands/sync.js';
 import update from './commands/update.js';
 import validate from './commands/validate.js';
 import { getVersion, showBanner } from './ui/banner.js';
+import { ensureSupportedRuntime } from './utils/runtime.js';
 
 const CLI_SUBCOMMANDS = {
   setup,
@@ -170,6 +171,8 @@ function normalizeCliArgs(argv: string[]): string[] {
 }
 
 process.argv = normalizeCliArgs(process.argv);
+
+ensureSupportedRuntime();
 
 const isVersion = process.argv.includes('--version') || process.argv.includes('-v');
 const subCommands = Object.keys(CLI_SUBCOMMANDS);

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,6 +2,7 @@ import { execFile as execFileCb } from 'node:child_process';
 import { defineCommand } from 'citty';
 import pc from 'picocolors';
 import pkg from '../../package.json';
+import { DEFAULT_NODE_MAJOR, SUPPORTED_NODE_MAJORS } from '../utils/runtime.js';
 import {
   configExists,
   getConfigLocationLabel,
@@ -105,12 +106,17 @@ async function toolSection(): Promise<SectionReport> {
     ok: true,
   });
 
-  // Runtime (Bun or Node)
+  // Active runtime and runtime policy
   const runtime =
     typeof globalThis.Bun !== 'undefined'
       ? `Bun ${(globalThis.Bun as { version?: string }).version ?? '?'}`
       : `Node ${process.version}`;
   checks.push({ label: runtime, ok: true, detail: `${process.platform}-${process.arch}` });
+  checks.push({
+    label: 'Node runtime policy',
+    ok: true,
+    detail: `default ${DEFAULT_NODE_MAJOR}; supports ${SUPPORTED_NODE_MAJORS.join(', ')}; Bun for dev/build/test`,
+  });
 
   return { title: 'Tool', checks };
 }

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,7 +2,6 @@ import { execFile as execFileCb } from 'node:child_process';
 import { defineCommand } from 'citty';
 import pc from 'picocolors';
 import pkg from '../../package.json';
-import { DEFAULT_NODE_MAJOR, SUPPORTED_NODE_MAJORS } from '../utils/runtime.js';
 import {
   configExists,
   getConfigLocationLabel,
@@ -26,6 +25,11 @@ import {
 } from '../utils/git.js';
 import { projectHeading } from '../utils/logger.js';
 import { detectForkSetup, parseRepoFromUrl } from '../utils/remote.js';
+import {
+  DEFAULT_NODE_MAJOR,
+  isSupportedNodeRuntime,
+  SUPPORTED_NODE_MAJORS,
+} from '../utils/runtime.js';
 import { hasOllamaCloudApiKey, hasOpenRouterApiKey, hasSecretsStore } from '../utils/secrets.js';
 import { getLocalStateLocationLabel, hasLocalStateStore } from '../utils/state.js';
 import {
@@ -112,10 +116,14 @@ async function toolSection(): Promise<SectionReport> {
       ? `Bun ${(globalThis.Bun as { version?: string }).version ?? '?'}`
       : `Node ${process.version}`;
   checks.push({ label: runtime, ok: true, detail: `${process.platform}-${process.arch}` });
+  const nodeOk = typeof globalThis.Bun !== 'undefined' || isSupportedNodeRuntime();
   checks.push({
     label: 'Node runtime policy',
-    ok: true,
-    detail: `default ${DEFAULT_NODE_MAJOR}; supports ${SUPPORTED_NODE_MAJORS.join(', ')}; Bun for dev/build/test`,
+    ok: nodeOk,
+    warning: !nodeOk,
+    detail: nodeOk
+      ? `default ${DEFAULT_NODE_MAJOR}; supports ${SUPPORTED_NODE_MAJORS.join(', ')}; Bun for dev/build/test`
+      : `Node ${process.version} is outside supported range (${SUPPORTED_NODE_MAJORS.join(', ')})`,
   });
 
   return { title: 'Tool', checks };

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -4,7 +4,7 @@ import pc from 'picocolors';
 import { promptForBranchName } from '../utils/branchPrompt.js';
 import { isAIEnabled, readConfig } from '../utils/config.js';
 import { confirmPrompt, selectPrompt } from '../utils/confirm.js';
-import { suggestConflictResolution } from '../utils/copilot.js';
+import { checkCopilotAvailable, suggestConflictResolution } from '../utils/copilot.js';
 import { getMergedPRForBranch } from '../utils/gh.js';
 import {
   assertCleanGitState,

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -14,7 +14,8 @@ export function isBunRuntime(): boolean {
 
 export function getNodeMajorVersion(context: RuntimeContext = {}): number | null {
   const nodeVersion = context.nodeVersion ?? process.versions.node;
-  const major = Number.parseInt((nodeVersion.startsWith('v') ? nodeVersion.slice(1) : nodeVersion).split('.')[0] ?? '', 10);
+  const normalized = nodeVersion.startsWith('v') ? nodeVersion.slice(1) : nodeVersion;
+  const major = Number.parseInt(normalized.split('.')[0] ?? '', 10);
 
   return Number.isFinite(major) ? major : null;
 }
@@ -75,7 +76,13 @@ export function getRuntimeGuardMessage(context: RuntimeContext = {}): string {
 
   lines.push(`Detected Node.js version: ${nodeVersion}`);
   lines.push('');
-  lines.push(`Use Node.js ${SUPPORTED_NODE_MAJORS.join(', ')} for the packaged CLI.`);
+  const majors = [...SUPPORTED_NODE_MAJORS] as number[];
+  const versionList =
+    majors.length > 1
+      ? `${majors.slice(0, -1).join(', ')}, or ${majors[majors.length - 1]}`
+      : `${majors[0]}`;
+
+  lines.push(`Use Node.js ${versionList} for the packaged CLI.`);
   lines.push('Bun remains the supported toolchain for local development, builds, and tests.');
   lines.push('');
   lines.push('Download Node.js:');

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -2,10 +2,37 @@ type RuntimeContext = {
   argv?: string[];
   env?: Record<string, string | undefined>;
   isBun?: boolean;
+  nodeVersion?: string;
 };
+
+export const DEFAULT_NODE_MAJOR = 26;
+export const SUPPORTED_NODE_MAJORS = [22, 24, 26] as const;
 
 export function isBunRuntime(): boolean {
   return typeof globalThis.Bun !== 'undefined';
+}
+
+export function getNodeMajorVersion(context: RuntimeContext = {}): number | null {
+  const nodeVersion = context.nodeVersion ?? process.versions.node;
+  const major = Number.parseInt(nodeVersion.split('.')[0] ?? '', 10);
+
+  return Number.isFinite(major) ? major : null;
+}
+
+export function isSupportedNodeRuntime(context: RuntimeContext = {}): boolean {
+  const major = getNodeMajorVersion(context);
+
+  return major !== null && SUPPORTED_NODE_MAJORS.includes(major as (typeof SUPPORTED_NODE_MAJORS)[number]);
+}
+
+export function isSupportedRuntime(context: RuntimeContext = {}): boolean {
+  const bunRuntime = context.isBun ?? isBunRuntime();
+
+  if (bunRuntime) {
+    return true;
+  }
+
+  return isSupportedNodeRuntime(context);
 }
 
 export function isNpxExecution(context: RuntimeContext = {}): boolean {
@@ -32,34 +59,44 @@ export function isNpxExecution(context: RuntimeContext = {}): boolean {
   return false;
 }
 
-export function getBunRuntimeGuardMessage(context: RuntimeContext = {}): string {
+export function getRuntimeGuardMessage(context: RuntimeContext = {}): string {
   const detectedNpx = isNpxExecution(context);
-  const lines = ['contribute-now requires Bun at runtime.', ''];
+  const nodeVersion = context.nodeVersion ?? process.versions.node;
+  const lines = ['contribute-now runs on Node.js at runtime.', ''];
+
+  lines.push(`Default runtime target: Node.js ${DEFAULT_NODE_MAJOR}.`);
+  lines.push(`Supported Node.js versions: ${SUPPORTED_NODE_MAJORS.join(', ')}.`);
+  lines.push('');
 
   if (detectedNpx) {
-    lines.push('You are running it with Node/npx or pnpx. Use Bun instead:');
-    lines.push('  bunx contribute-now setup');
+    lines.push('npx/pnpx execution is supported, but the current Node.js runtime is outside the supported range.');
     lines.push('');
   }
 
-  lines.push('Install Bun first:');
-  lines.push('  npm install -g bun');
+  lines.push(`Detected Node.js version: ${nodeVersion}`);
   lines.push('');
-  lines.push('Then verify:');
-  lines.push('  bun --version');
+  lines.push('Use Node.js 22, 24, or 26 for the packaged CLI.');
+  lines.push('Bun remains the supported toolchain for local development, builds, and tests.');
   lines.push('');
-  lines.push('Official install guide:');
-  lines.push('  https://bun.sh/docs/installation');
+  lines.push('Download Node.js:');
+  lines.push('  https://nodejs.org/');
 
   return lines.join('\n');
 }
 
-export function ensureBunRuntime(context: RuntimeContext = {}): void {
-  const bunRuntime = context.isBun ?? isBunRuntime();
-  if (bunRuntime) {
+export function getBunRuntimeGuardMessage(context: RuntimeContext = {}): string {
+  return getRuntimeGuardMessage(context);
+}
+
+export function ensureSupportedRuntime(context: RuntimeContext = {}): void {
+  if (isSupportedRuntime(context)) {
     return;
   }
 
-  console.error(getBunRuntimeGuardMessage(context));
+  console.error(getRuntimeGuardMessage(context));
   process.exit(1);
+}
+
+export function ensureBunRuntime(context: RuntimeContext = {}): void {
+  ensureSupportedRuntime(context);
 }

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -14,7 +14,7 @@ export function isBunRuntime(): boolean {
 
 export function getNodeMajorVersion(context: RuntimeContext = {}): number | null {
   const nodeVersion = context.nodeVersion ?? process.versions.node;
-  const major = Number.parseInt(nodeVersion.split('.')[0] ?? '', 10);
+  const major = Number.parseInt((nodeVersion.startsWith('v') ? nodeVersion.slice(1) : nodeVersion).split('.')[0] ?? '', 10);
 
   return Number.isFinite(major) ? major : null;
 }
@@ -75,7 +75,7 @@ export function getRuntimeGuardMessage(context: RuntimeContext = {}): string {
 
   lines.push(`Detected Node.js version: ${nodeVersion}`);
   lines.push('');
-  lines.push('Use Node.js 22, 24, or 26 for the packaged CLI.');
+  lines.push(`Use Node.js ${SUPPORTED_NODE_MAJORS.join(', ')} for the packaged CLI.`);
   lines.push('Bun remains the supported toolchain for local development, builds, and tests.');
   lines.push('');
   lines.push('Download Node.js:');

--- a/tests/utils/runtime.test.ts
+++ b/tests/utils/runtime.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
 import {
+  ensureSupportedRuntime,
   ensureBunRuntime,
   getBunRuntimeGuardMessage,
+  getNodeMajorVersion,
+  getRuntimeGuardMessage,
+  isSupportedNodeRuntime,
+  isSupportedRuntime,
   isNpxExecution,
 } from '../../src/utils/runtime.js';
 
@@ -88,32 +93,76 @@ describe('isNpxExecution', () => {
   });
 });
 
-describe('getBunRuntimeGuardMessage', () => {
-  it('suggests bunx when npx execution is detected', () => {
-    const message = getBunRuntimeGuardMessage({ argv: ['/usr/bin/npx', 'contribute-now'] });
-
-    expect(message).toContain('You are running it with Node/npx or pnpx. Use Bun instead:');
-    expect(message).toContain('bunx contribute-now setup');
-    expect(message).toContain('npm install -g bun');
+describe('getNodeMajorVersion', () => {
+  it('returns the major version when Node.js is valid', () => {
+    expect(getNodeMajorVersion({ nodeVersion: '26.0.0' })).toBe(26);
   });
 
-  it('suggests bunx when pnpx execution is detected', () => {
-    const message = getBunRuntimeGuardMessage({ argv: ['/usr/bin/pnpx', 'contribute-now'] });
-
-    expect(message).toContain('You are running it with Node/npx or pnpx. Use Bun instead:');
-    expect(message).toContain('bunx contribute-now setup');
-  });
-
-  it('returns the generic Bun install guidance otherwise', () => {
-    const message = getBunRuntimeGuardMessage({ argv: ['node', 'dist/index.js'] });
-
-    expect(message).not.toContain('You are running it with Node/npx or pnpx');
-    expect(message).toContain('contribute-now requires Bun at runtime.');
-    expect(message).toContain('https://bun.sh/docs/installation');
+  it('returns null when Node.js cannot be parsed', () => {
+    expect(getNodeMajorVersion({ nodeVersion: 'invalid' })).toBeNull();
   });
 });
 
-describe('ensureBunRuntime', () => {
+describe('isSupportedNodeRuntime', () => {
+  it('accepts Node.js 22, 24, and 26', () => {
+    expect(isSupportedNodeRuntime({ nodeVersion: '22.15.0' })).toBe(true);
+    expect(isSupportedNodeRuntime({ nodeVersion: '24.3.1' })).toBe(true);
+    expect(isSupportedNodeRuntime({ nodeVersion: '26.0.0' })).toBe(true);
+  });
+
+  it('rejects unsupported Node.js majors', () => {
+    expect(isSupportedNodeRuntime({ nodeVersion: '21.9.0' })).toBe(false);
+    expect(isSupportedNodeRuntime({ nodeVersion: '27.0.0' })).toBe(false);
+  });
+});
+
+describe('isSupportedRuntime', () => {
+  it('accepts Bun as the development toolchain runtime', () => {
+    expect(isSupportedRuntime({ isBun: true })).toBe(true);
+  });
+
+  it('accepts supported Node.js runtimes', () => {
+    expect(isSupportedRuntime({ isBun: false, nodeVersion: '24.8.0' })).toBe(true);
+  });
+
+  it('rejects unsupported Node.js runtimes', () => {
+    expect(isSupportedRuntime({ isBun: false, nodeVersion: '20.18.0' })).toBe(false);
+  });
+});
+
+describe('getRuntimeGuardMessage', () => {
+  it('explains the supported Node.js policy for npx execution', () => {
+    const message = getRuntimeGuardMessage({
+      argv: ['/usr/bin/npx', 'contribute-now'],
+      nodeVersion: '20.18.0',
+    });
+
+    expect(message).toContain('contribute-now runs on Node.js at runtime.');
+    expect(message).toContain('Default runtime target: Node.js 26.');
+    expect(message).toContain('Supported Node.js versions: 22, 24, 26.');
+    expect(message).toContain('npx/pnpx execution is supported');
+  });
+
+  it('returns generic Node.js guidance otherwise', () => {
+    const message = getRuntimeGuardMessage({
+      argv: ['node', 'dist/cli.js'],
+      nodeVersion: '20.18.0',
+    });
+
+    expect(message).not.toContain('npx/pnpx execution is supported');
+    expect(message).toContain('Use Node.js 22, 24, or 26 for the packaged CLI.');
+    expect(message).toContain('Bun remains the supported toolchain for local development, builds, and tests.');
+    expect(message).toContain('https://nodejs.org/');
+  });
+
+  it('keeps the legacy alias wired to the new message', () => {
+    expect(getBunRuntimeGuardMessage({ nodeVersion: '20.18.0' })).toBe(
+      getRuntimeGuardMessage({ nodeVersion: '20.18.0' }),
+    );
+  });
+});
+
+describe('ensureSupportedRuntime', () => {
   it('does nothing when Bun is available', () => {
     const logged: string[] = [];
     let exitCode: number | undefined;
@@ -126,31 +175,31 @@ describe('ensureBunRuntime', () => {
       return undefined as never;
     }) as typeof process.exit;
 
-    ensureBunRuntime({ isBun: true });
+    ensureSupportedRuntime({ isBun: true });
 
     expect(logged).toHaveLength(0);
     expect(exitCode).toBeUndefined();
   });
 
-  it('prints the guard message and exits with code 1 when Bun is unavailable', () => {
+  it('does nothing when Node.js is supported', () => {
     const logged: string[] = [];
+    let exitCode: number | undefined;
 
     console.error = (message?: unknown) => {
       logged.push(String(message ?? ''));
     };
     process.exit = ((code?: number) => {
-      throw new Error(`exit:${String(code)}`);
+      exitCode = code;
+      return undefined as never;
     }) as typeof process.exit;
 
-    expect(() => ensureBunRuntime({ isBun: false, argv: ['node', 'dist/index.js'] })).toThrow(
-      'exit:1',
-    );
-    expect(logged).toHaveLength(1);
-    expect(logged[0]).toContain('contribute-now requires Bun at runtime.');
-    expect(logged[0]).toContain('npm install -g bun');
+    ensureSupportedRuntime({ isBun: false, nodeVersion: '22.15.0' });
+
+    expect(logged).toHaveLength(0);
+    expect(exitCode).toBeUndefined();
   });
 
-  it('includes bunx guidance when exiting from npx-style execution', () => {
+  it('prints the guard message and exits with code 1 when Node.js is unsupported', () => {
     const logged: string[] = [];
 
     console.error = (message?: unknown) => {
@@ -161,11 +210,50 @@ describe('ensureBunRuntime', () => {
     }) as typeof process.exit;
 
     expect(() =>
-      ensureBunRuntime({
+      ensureSupportedRuntime({
         isBun: false,
-        argv: ['/usr/bin/npx', 'contribute-now'],
+        argv: ['node', 'dist/cli.js'],
+        nodeVersion: '20.18.0',
       }),
     ).toThrow('exit:1');
-    expect(logged[0]).toContain('bunx contribute-now setup');
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain('Supported Node.js versions: 22, 24, 26.');
+    expect(logged[0]).toContain('Detected Node.js version: 20.18.0');
+  });
+
+  it('includes npx guidance when exiting from npx-style execution', () => {
+    const logged: string[] = [];
+
+    console.error = (message?: unknown) => {
+      logged.push(String(message ?? ''));
+    };
+    process.exit = ((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit;
+
+    expect(() =>
+      ensureSupportedRuntime({
+        isBun: false,
+        argv: ['/usr/bin/npx', 'contribute-now'],
+        nodeVersion: '20.18.0',
+      }),
+    ).toThrow('exit:1');
+    expect(logged[0]).toContain('npx/pnpx execution is supported');
+  });
+});
+
+describe('ensureBunRuntime', () => {
+  it('keeps the legacy alias wired to supported runtime checks', () => {
+    const logged: string[] = [];
+
+    console.error = (message?: unknown) => {
+      logged.push(String(message ?? ''));
+    };
+    process.exit = ((code?: number) => {
+      throw new Error(`exit:${String(code)}`);
+    }) as typeof process.exit;
+
+    expect(() => ensureBunRuntime({ isBun: false, nodeVersion: '20.18.0' })).toThrow('exit:1');
+    expect(logged[0]).toContain('contribute-now runs on Node.js at runtime.');
   });
 });


### PR DESCRIPTION
This pull request updates the CLI build process and script compatibility to target Node.js instead of Bun, and also imports a new utility function for Copilot availability checks. The most important changes are:

**Build and Runtime Environment Updates:**

* Changed the `build` script in `package.json` to target Node.js (`--target node`) instead of Bun, ensuring the built CLI runs in a Node.js environment.
* Updated the shebang line in `scripts/add-shebang.mjs` from `#!/usr/bin/env bun` to `#!/usr/bin/env node`, making the built CLI script executable with Node.js.

**Copilot Utility Import:**

* Modified the import in `src/commands/update.ts` to include the new `checkCopilotAvailable` function from `utils/copilot.js`, preparing for future use of Copilot availability checks.