### PR TITLE
📖 docs: note ssh agent setup for WSL2 contributors

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -43,6 +43,7 @@ jobs:
         run: bun test
 
       - name: Publish
+        id: publish
         uses: wgtechlabs/package-build-flow-action@v2.1.1
         with:
           package-manager: 'bun'
@@ -50,5 +51,21 @@ jobs:
           package-scope: '@warengonzaga'
           access: 'public'
           npm-token: "${{ secrets.NPM_TOKEN }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT || secrets.GITHUB_TOKEN }}"
           dry-run: "${{ github.event.inputs.dry-run || 'false' }}"
+
+      - name: Verify publish outputs
+        if: "${{ (github.event.inputs.dry-run || 'false') != 'true' }}"
+        run: |
+          echo "npm-published=${{ steps.publish.outputs.npm-published }}"
+          echo "github-published=${{ steps.publish.outputs.github-published }}"
+
+          if [ "${{ steps.publish.outputs.npm-published }}" != "true" ]; then
+            echo "Expected NPM publish to succeed but got '${{ steps.publish.outputs.npm-published }}'"
+            exit 1
+          fi
+
+          if [ "${{ steps.publish.outputs.github-published }}" != "true" ]; then
+            echo "Expected GitHub Packages publish to succeed but got '${{ steps.publish.outputs.github-published }}'"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.10.1] - 2026-06-02
+
+### Changed
+
+- fix engines.node range, runtime guard, and doctor validation
+- improve readability of v-prefix strip and version list formatting
+- align runtime with Node 26 policy
+- import checkCopilotAvailable in update command (#24)
+- switch build target from bun to node for cross-runtime compat (#25)
+
+### Fixed
+
+- address review comments in runtime.ts and README.md
+
 ## [0.10.0] - 2026-05-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.9.0] - 2026-05-04
+
+### Added
+
+- add deterministic `cn label add` / `cn label suggest` commands with cached label source strategy (#18)
+- add OpenRouter as a supported AI provider (#16)
+
 ## [0.8.0] - 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 
+
+## [0.10.0] - 2026-05-05
+
+### Added
+
+- extract label utility and refactor copilot module
+- add git utility and clean up gh helper
+- add label apply command with bulk and AI support
+- add generateLabelRankings AI utility
+- add listOpenIssues, listOpenPRs, getIssueDetails, getPRDetails utils
+- add global AI defaults support (#20)
+
+### Changed
+
+- expose sync and prune flags in branch command
+- add sync and prune support to git utilities
+- enhance version display and compact help UI
+- update label command
+- add LICENSE file
+- reuse stored AI keys during setup (#21)
+
+### Security
+
+- surface error on corrupt global config file
+
 ## [0.9.0] - 2026-05-04
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -482,6 +482,15 @@ bun test        # run tests
 bun run lint    # check code quality
 ```
 
+If you use an SSH remote and your key has a passphrase, set up an SSH agent in WSL2 before cloning or running the CLI so Git can reuse the unlocked key instead of prompting on every new shell or command. A simple option is:
+
+```bash
+eval "$(ssh-agent -s)"
+ssh-add ~/.ssh/id_ed25519
+```
+
+If you want the agent to come back automatically in new shells, use a helper like `keychain` and load it from `~/.bashrc`.
+
 Bun powers local development, build, and test workflows. The packaged CLI runs on Node.js 22, 24, or 26, with Node.js 26 as the default runtime target.
 
 ## 🎯 Contributing
@@ -517,7 +526,3 @@ This project is licensed under [GNU General Public License v3.0](https://opensou
 This project is created by **[Waren Gonzaga](https://github.com/warengonzaga)**, with the help of awesome [contributors](https://github.com/warengonzaga/contribute-now/graphs/contributors).
 
 [![contributors](https://cn.rocks/image?repo=warengonzaga/contribute-now)](https://github.com/warengonzaga/contribute-now/graphs/contributors)
-
----
-
-💻💖☕ by [Waren Gonzaga](https://warengonzaga.com) & [YHWH](https://www.youtube.com/watch?v=VOZbswniA-g) 🙏 — Without *Him*, none of this exists, *even me*.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contribute-now",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Developer CLI that automates git workflows — branching, syncing, committing, and PRs — with multi-workflow and commit convention support.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contribute-now",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Developer CLI that automates git workflows — branching, syncing, committing, and PRs — with multi-workflow and commit convention support.",
   "type": "module",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contribute-now",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Developer CLI that automates git workflows — branching, syncing, committing, and PRs — with multi-workflow and commit convention support.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Add a short README note for contributors using SSH in WSL2 so they can cache an unlocked key with ssh-agent instead of re-entering the passphrase on every shell.

This keeps the guidance close to the project setup steps and targets the `dev` branch as requested.